### PR TITLE
static: split cli, engine, and containerd packages

### DIFF
--- a/static/Makefile
+++ b/static/Makefile
@@ -17,6 +17,12 @@ export COMPOSE_DIR
 export SCAN_DIR
 
 export STATIC_VERSION
+
+# Select the default version of containerd based on the docker engine source
+# we need this variable here for naming the produced .tgz file.
+# TODO containerd binaries should be built as part of containerd-packaging, not as part of docker/docker-ce-packaging
+CONTAINERD_VERSION?=v$(shell grep "ARG CONTAINERD_VERSION" "$(ENGINE_DIR)/Dockerfile.windows" | awk -F'=' '{print $$2}')
+
 export CONTAINERD_VERSION
 export RUNC_VERSION
 

--- a/static/build-static
+++ b/static/build-static
@@ -122,6 +122,7 @@ echo "UNAME=$(uname -m)"
 echo "TARGETPLATFORM=${TARGETPLATFORM}"
 echo "CURPLATFORM=${CURPLATFORM}"
 echo "CROSS=${CROSS}"
+echo "CONTAINERD_VERSION=${CONTAINERD_VERSION}"
 
 cgo_enabled=""
 if [ "$TARGETARCH" = "arm" ] && [ -n "$TARGETVARIANT" ]; then
@@ -135,7 +136,9 @@ fi
 
 buildDir="${CURDIR}/build/${TARGETPLATFORM}"
 
-dockerBuildDir="${buildDir}/docker"
+dockerCLIBuildDir="${buildDir}/docker-cli"
+dockerBuildDir="${buildDir}/docker-engine"
+containerdBuildDir="${buildDir}/containerd"
 rootlessExtrasBuildDir="${buildDir}/docker-rootless-extras"
 buildxBuildDir="${buildDir}/docker-buildx"
 composeBuildDir="${buildDir}/docker-compose"
@@ -180,21 +183,47 @@ esac
 # cleanup
 [ -d "${buildDir}" ] && rm -r "${buildDir}"
 
-# docker
-mkdir -p "${dockerBuildDir}"
+# docker CLI
+mkdir -p "${dockerCLIBuildDir}"
 case ${TARGETOS} in
 	linux | darwin)
-		cp "${CLI_DIR}"/build/"${targetPair}"/docker-"${TARGETOS}"-* "${dockerBuildDir}/docker"
+		cp "${CLI_DIR}"/build/"${targetPair}"/docker-"${TARGETOS}"-* "${dockerCLIBuildDir}/docker"
 		;;
 	windows)
-		cp "${CLI_DIR}"/build/"${targetPair}"/docker-"${TARGETOS}"-*.exe "${dockerBuildDir}/docker.exe"
+		cp "${CLI_DIR}"/build/"${targetPair}"/docker-"${TARGETOS}"-*.exe "${dockerCLIBuildDir}/docker.exe"
 		;;
 esac
+# package docker CLI
+case ${TARGETOS} in
+	linux | darwin)
+		(
+			set -x
+			tar -C "${buildDir}" -c -z -f "${buildDir}/docker-cli-${STATIC_VERSION}.tgz" docker-cli
+		)
+		;;
+	windows)
+		(
+			cd "${buildDir}"
+			set -x
+			zip -r "docker-cli-${STATIC_VERSION}.zip" docker-cli
+		)
+		;;
+esac
+
+# docker, containerd, and runc
+mkdir -p "${dockerBuildDir}"
 case ${TARGETOS} in
 	linux)
-		for f in dockerd containerd ctr containerd-shim containerd-shim-runc-v2 docker-init docker-proxy runc; do
+		for f in dockerd docker-init docker-proxy; do
 			if [ -f "${ENGINE_DIR}/bundles/${TARGETPLATFORM}/$f" ]; then
 				cp -L "${ENGINE_DIR}/bundles/${TARGETPLATFORM}/$f" "${dockerBuildDir}/$f"
+			fi
+		done
+		# TODO containerd binaries should be built as part of containerd-packaging, not as part of docker/docker-ce-packaging
+		mkdir -p "${containerdBuildDir}"
+		for f in containerd ctr containerd-shim containerd-shim-runc-v2 runc; do
+			if [ -f "${ENGINE_DIR}/bundles/${TARGETPLATFORM}/$f" ]; then
+				cp -L "${ENGINE_DIR}/bundles/${TARGETPLATFORM}/$f" "${containerdBuildDir}/$f"
 			fi
 		done
 		;;
@@ -203,19 +232,26 @@ case ${TARGETOS} in
 		cp "${ENGINE_DIR}"/bundles/"${TARGETPLATFORM}"/docker-proxy-*.exe "${dockerBuildDir}/docker-proxy.exe"
 		;;
 esac
-# package docker
+# package docker, containerd, and runc
 case ${TARGETOS} in
-	linux | darwin)
+	darwin)
 		(
 			set -x
-			tar -C "${buildDir}" -c -z -f "${buildDir}/docker-${STATIC_VERSION}.tar.tgz" docker
+			tar -C "${buildDir}" -c -z -f "${buildDir}/docker-engine-${STATIC_VERSION}.tgz" docker-engine
+		)
+		;;
+	linux)
+		(
+			set -x
+			tar -C "${buildDir}" -c -z -f "${buildDir}/docker-engine-${STATIC_VERSION}.tgz" docker-engine
+			tar -C "${buildDir}" -c -z -f "${buildDir}/containerd-${CONTAINERD_VERSION#v}.tgz" containerd
 		)
 		;;
 	windows)
 		(
 			cd "${buildDir}"
 			set -x
-			zip -r "docker-${STATIC_VERSION}.zip" docker
+			zip -r "docker-engine-${STATIC_VERSION}.zip" docker-engine
 		)
 		;;
 esac
@@ -237,7 +273,7 @@ if [ -d "${rootlessExtrasBuildDir}" ]; then
 		linux)
 			(
 				set -x
-				tar -C "${buildDir}" -c -z -f "${buildDir}/docker-rootless-extras-${STATIC_VERSION}.tar.tgz" docker-rootless-extras
+				tar -C "${buildDir}" -c -z -f "${buildDir}/docker-rootless-extras-${STATIC_VERSION}.tgz" docker-rootless-extras
 			)
 			;;
 	esac
@@ -259,7 +295,7 @@ if [ -d "${BUILDX_DIR}/bin" ]; then
 		linux | darwin)
 			(
 				set -x
-				tar -C "${buildDir}" -c -z -f "${buildDir}/docker-buildx-plugin-${DOCKER_BUILDX_REF#v}.tar.gz" docker-buildx
+				tar -C "${buildDir}" -c -z -f "${buildDir}/docker-buildx-plugin-${DOCKER_BUILDX_REF#v}.tgz" docker-buildx
 			)
 			;;
 		windows)
@@ -303,7 +339,7 @@ if [ -d "${COMPOSE_DIR}/bin" ]; then
 		linux | darwin)
 			(
 				set -x
-				tar -C "${buildDir}" -c -z -f "${buildDir}/docker-compose-plugin-${DOCKER_COMPOSE_REF#v}.tar.gz" docker-compose
+				tar -C "${buildDir}" -c -z -f "${buildDir}/docker-compose-plugin-${DOCKER_COMPOSE_REF#v}.tgz" docker-compose
 			)
 			;;
 		windows)
@@ -332,7 +368,7 @@ if [ -d "${SCAN_DIR}/dist" ]; then
 		linux | darwin)
 			(
 				set -x
-				tar -C "${buildDir}" -c -z -f "${buildDir}/docker-scan-plugin-${DOCKER_SCAN_REF#v}.tar.gz" docker-scan
+				tar -C "${buildDir}" -c -z -f "${buildDir}/docker-scan-plugin-${DOCKER_SCAN_REF#v}.tgz" docker-scan
 			)
 			;;
 		windows)
@@ -350,5 +386,6 @@ fi
 	set -x
 	cd "${buildDir}"
 	rm -r */
+	# bundle is expected to have a tar.gz extension, unlike the other archives, which use .tgz
 	tar -zvcf "${CURDIR}/build/bundles-ce-static-${TARGETOS}-${BUNDLEARCH}.tar.gz" .
 )


### PR DESCRIPTION
This splits the CLI, Engine, and containerd packages to allow downloading
the cli separate from the daemon, as well as (in future) allowing us to
do a containerd release without also requiring an engine release.

With this patch:

    make REF=v22.06.0-beta.0 VERSION=v22.06.0-beta.0 TARGETPLATFORM=linux/amd64 static

    static/build
    ├── bundles-ce-static-linux-x86_64.tar.gz
    └── linux
        └── amd64
            ├── containerd-1.6.4.tgz
            ├── docker-buildx-plugin-0.8.2.tgz
            ├── docker-cli-22.06.0-beta.0.tgz
            ├── docker-compose-plugin-2.6.1.tgz
            ├── docker-engine-22.06.0-beta.0.tgz
            ├── docker-rootless-extras-22.06.0-beta.0.tgz
            └── docker-scan-plugin-0.17.0.tgz

    2 directories, 8 files

    ls -lh static/build/linux/amd64/
    total 215208
    -rw-r--r--  1 sebastiaan  staff    31M Jun 29 00:21 containerd-1.6.4.tgz
    -rw-r--r--  1 sebastiaan  staff    14M Jun 29 00:21 docker-buildx-plugin-0.8.2.tgz
    -rw-r--r--  1 sebastiaan  staff   8.2M Jun 29 00:21 docker-cli-22.06.0-beta.0.tgz
    -rw-r--r--  1 sebastiaan  staff   8.8M Jun 29 00:21 docker-compose-plugin-2.6.1.tgz
    -rw-r--r--  1 sebastiaan  staff    19M Jun 29 00:21 docker-engine-22.06.0-beta.0.tgz
    -rw-r--r--  1 sebastiaan  staff    19M Jun 29 00:21 docker-rootless-extras-22.06.0-beta.0.tgz
    -rw-r--r--  1 sebastiaan  staff   4.4M Jun 29 00:21 docker-scan-plugin-0.17.0.tgz
